### PR TITLE
allow showing any content-type in calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ https://user-images.githubusercontent.com/4497578/154287664-6153ae22-27dd-48ed-9
 ```
 More details checkout the following link: https://5.docs.plone.org/external/plone.app.dexterity/docs/advanced/catalog-indexing-strategies.html#adding-new-indexes-and-metadata-columns
 
+### Add content-types other than Events in the Calendar
+
+You may have developed a custom version of an Event that want to show in a calendar, or you may have other content-types that want to show in a calendar.
+
+To do so, you need to provide a function that returns the date, title and urls to show for your content-type.
+
+You need to register that function in the block config in your addon this way:
+
+
+```js
+config.blocks.blocksConfig.fullcalendar['YourContentType'] = (item) => {
+  return {
+    title: item.title,
+    start: item.XXX, # <- point this attribute to the one that provides the start date
+    end: item.XXXX,  # <- point this attribute to the one that provides the end date
+    url: flattenToAppURL[item['@id']] # <- point this attribute to the one that provides the url you want to go when clicking the event in the calendar
+  }
+};
+
+```
+
+The block already includes a default function for the Event content-type.
+
 
 ### Calendar block for remote events
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ More details checkout the following link: https://5.docs.plone.org/external/plon
 
 You may have developed a custom version of an event or other content types that want to show in a calendar.
 
-To do so, you need to provide a function that returns the date, title and urls to show for your content-type.
+To do so, you need to provide a function that returns the date, title, and URLs to show for your content type.
 
 You need to register that function in the block config in your addon this way:
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You need to register that function in the block config in your addon this way:
 
 
 ```js
-config.blocks.blocksConfig.fullcalendar['YourContentType'] = (item) => {
+config.blocks.blocksConfig.fullcalendar.contentConverters['YourContentType'] = (item) => {
   return {
     title: item.title,
     start: item.XXX, # <- point this attribute to the one that provides the start date

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://user-images.githubusercontent.com/4497578/154287664-6153ae22-27dd-48ed-9
 ```
 More details checkout the following link: https://5.docs.plone.org/external/plone.app.dexterity/docs/advanced/catalog-indexing-strategies.html#adding-new-indexes-and-metadata-columns
 
-### Add content-types other than Events in the Calendar
+### Add content types other than events in the calendar
 
 You may have developed a custom version of an Event that want to show in a calendar, or you may have other content-types that want to show in a calendar.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ config.blocks.blocksConfig.fullcalendar.contentConverters['YourContentType'] = (
 
 ```
 
-The block already includes a default function for the Event content-type.
+The block already includes a default function for the event content type.
 
 
 ### Calendar block for remote events

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ More details checkout the following link: https://5.docs.plone.org/external/plon
 
 ### Add content types other than events in the calendar
 
-You may have developed a custom version of an Event that want to show in a calendar, or you may have other content-types that want to show in a calendar.
+You may have developed a custom version of an event or other content types that want to show in a calendar.
 
 To do so, you need to provide a function that returns the date, title and urls to show for your content-type.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You may have developed a custom version of an event or other content types that 
 
 To do so, you need to provide a function that returns the date, title, and URLs to show for your content type.
 
-You need to register that function in the block config in your addon this way:
+You need to register that function in the block configuration in your add-on this way:
 
 
 ```js

--- a/src/components/manage/Blocks/Listing/FullCalendar.jsx
+++ b/src/components/manage/Blocks/Listing/FullCalendar.jsx
@@ -9,7 +9,7 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import { RRule, rrulestr } from 'rrule';
 import messages from '../FullCalendar/messages';
-import config from '@plone/volto';
+import config from '@plone/volto/registry';
 
 /* returns all events, computed by the reccurence rule of an Event item */
 const expand = (item) => {

--- a/src/components/manage/Blocks/Listing/FullCalendar.jsx
+++ b/src/components/manage/Blocks/Listing/FullCalendar.jsx
@@ -9,6 +9,7 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import { RRule, rrulestr } from 'rrule';
 import messages from '../FullCalendar/messages';
+import config from '@plone/volto';
 
 /* returns all events, computed by the reccurence rule of an Event item */
 const expand = (item) => {
@@ -59,9 +60,13 @@ const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
 
   let recurrences = [];
 
+  const contentConverters =
+    config.blocks.blocksConfig.fullcalendar.contentConverters;
+
   let events = items
     .filter((i) => {
-      if (i['@type'] !== 'Event') return false;
+      if (!Object.keys().includes(i['@type'])) return false;
+
       if (i.recurrence) {
         recurrences = recurrences.concat(expand(i));
         /* expand returns initial event as well, so we skip it here */
@@ -70,12 +75,7 @@ const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
       return true;
     })
     .map((i) => {
-      return {
-        title: i.title,
-        start: i.start,
-        end: i.end,
-        url: flattenToAppURL(i['@id']),
-      };
+      return contentConverters[i['@type']](i);
     });
 
   events = events.concat(recurrences);

--- a/src/components/manage/Blocks/Listing/FullCalendar.jsx
+++ b/src/components/manage/Blocks/Listing/FullCalendar.jsx
@@ -65,7 +65,7 @@ const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
 
   let events = items
     .filter((i) => {
-      if (!Object.keys().includes(i['@type'])) return false;
+      if (!Object.keys(contentConverters).includes(i['@type'])) return false;
 
       if (i.recurrence) {
         recurrences = recurrences.concat(expand(i));

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   FullCalendarListing,
 } from './components';
 import FullCalendarBlockSchema from './components/manage/Blocks/FullCalendar/schema';
+import { flattenToAppURL } from '@plone/volto/helpers';
 
 const applyConfig = (config) => {
   config.blocks.blocksConfig.fullcalendar = {
@@ -21,6 +22,16 @@ const applyConfig = (config) => {
     security: {
       addPermission: [],
       view: [],
+    },
+    contentConverters: {
+      Event: (item) => {
+        return {
+          title: item.title,
+          start: item.start,
+          end: item.end,
+          url: flattenToAppURL(item['@id']),
+        };
+      },
     },
   };
 


### PR DESCRIPTION
I am still testing this (I can't make this addon work in Volto 17 because of some Webpack issues which I don't understand), but I think that with these changes we can make this plugin more flexible and allow showing any content object in the calendar view of a listing provided the integrator/developer implements a function with the information to show on it.