### PR TITLE
compatibility with Webpack 5 & Volto 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@fullcalendar/icalendar": "5.9.0",
     "@fullcalendar/list": "5.9.0",
     "@fullcalendar/react": "5.9.0",
-    "@fullcalendar/timegrid": "5.9.0"
+    "@fullcalendar/timegrid": "5.9.0",
+    "node-polyfill-webpack-plugin": "3.0.0"
   },
   "devDependencies": {
     "cypress": "11.1.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "@fullcalendar/icalendar": "5.9.0",
     "@fullcalendar/list": "5.9.0",
     "@fullcalendar/react": "5.9.0",
-    "@fullcalendar/timegrid": "5.9.0",
-    "node-polyfill-webpack-plugin": "3.0.0"
+    "@fullcalendar/timegrid": "5.9.0"
   },
   "devDependencies": {
     "cypress": "11.1.0"

--- a/razzle.extend.js
+++ b/razzle.extend.js
@@ -9,6 +9,9 @@ module.exports = {
       fs: false,
       net: false,
       dns: false,
+      path: false,
+      stream: false,
+      'stream-http': false,
     };
     return config;
   },

--- a/razzle.extend.js
+++ b/razzle.extend.js
@@ -1,0 +1,18 @@
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
+
+const plugins = (defaultPlugins) => {
+  return defaultPlugins;
+};
+
+module.exports = {
+  plugins,
+  modify: (config, { target, dev }, webpack) => {
+    config.plugins.push(new NodePolyfillPlugin());
+    config.resolve.fallback = {
+      fs: false,
+      net: false,
+      dns: false,
+    };
+    return config;
+  },
+};

--- a/razzle.extend.js
+++ b/razzle.extend.js
@@ -1,5 +1,3 @@
-const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
-
 const plugins = (defaultPlugins) => {
   return defaultPlugins;
 };
@@ -7,7 +5,6 @@ const plugins = (defaultPlugins) => {
 module.exports = {
   plugins,
   modify: (config, { target, dev }, webpack) => {
-    config.plugins.push(new NodePolyfillPlugin());
     config.resolve.fallback = {
       fs: false,
       net: false,


### PR DESCRIPTION
When trying to use this addon in Volto 17, I got an error saying that Webpack 5 doesn't include anymore the polyfills for several node packages.

Without fully understanding what it means, I followed some Stackoverflow guidance :crossed_fingers: and fixed it with the changes in this PR.

I followed the following post to fix it:

- https://stackoverflow.com/questions/64557638/how-to-polyfill-node-core-modules-in-webpack-5

I have checked the working of the block and it works as expected. I don't know if I have touched any internals with those changes...
