### PR TITLE
Add @fullcalendar/google-calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
   "dependencies": {
     "@fullcalendar/core": "5.9.0",
     "@fullcalendar/daygrid": "5.9.0",
+    "@fullcalendar/google-calendar": "5.9.0",
     "@fullcalendar/icalendar": "5.9.0",
     "@fullcalendar/list": "5.9.0",
     "@fullcalendar/react": "5.9.0",
     "@fullcalendar/timegrid": "5.9.0"
   },
   "devDependencies": {
-    "cypress": "11.1.0",
-    "@plone/scripts": "^3.0.0"
+    "@plone/scripts": "^3.0.0",
+    "cypress": "11.1.0"
   }
 }

--- a/src/components/manage/Blocks/FullCalendar/View.jsx
+++ b/src/components/manage/Blocks/FullCalendar/View.jsx
@@ -6,6 +6,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import listPlugin from '@fullcalendar/list';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import iCalendarPlugin from '@fullcalendar/icalendar';
+import googleCalendarPlugin from '@fullcalendar/google-calendar'
 import allLocales from '@fullcalendar/core/locales-all';
 import './fullcalendar.less';
 import messages from './messages';
@@ -41,6 +42,11 @@ const FullCalendarBlockView = (props) => {
           url: data.calendar_url,
           format: 'ics',
         }
+      :
+    data.calendar_url && data.calendar_url.includes('@group.calendar.google.com')
+      ? {
+        googleCalendarId: data.calendar_url
+      }
       : {};
 
   const calendarRef = useRef(null);
@@ -52,7 +58,7 @@ const FullCalendarBlockView = (props) => {
   const [storedEvents, setStoredEvents] = useState([]);
 
   useEffect(() => {
-    if (data.calendar_url && isValidURL(data.calendar_url)) {
+    if (data.calendar_url && (isValidURL(data.calendar_url) || data.calendar_url.includes('@group.calendar.google.com'))) {
       setStoredEvents(null);
     }
   }, [data.calendar_url]);
@@ -78,7 +84,8 @@ const FullCalendarBlockView = (props) => {
 
   const fcOptions = {
     initialDate: data.initial_date || null,
-    plugins: [dayGridPlugin, iCalendarPlugin, listPlugin, timeGridPlugin],
+    plugins: [dayGridPlugin, iCalendarPlugin, listPlugin, timeGridPlugin, googleCalendarPlugin],
+    googleCalendarApiKey: data.google_calendar_api_key,
     buttonText: {
       dayGridMonth: intl.formatMessage(messages.labelDayGridMonth),
       timeGridWeek: intl.formatMessage(messages.labelTimeGridWeek),

--- a/src/components/manage/Blocks/FullCalendar/messages.js
+++ b/src/components/manage/Blocks/FullCalendar/messages.js
@@ -10,12 +10,20 @@ const messages = defineMessages({
     defaultMessage: 'Calendar Settings',
   },
   labelCalendarURL: {
-    id: 'Calendar URL',
-    defaultMessage: 'Calendar URL',
+    id: 'Calendar URL or Google Calendar ID',
+    defaultMessage: 'Calendar URL or Google Calendar ID',
+  },
+  labelGoogleCalendarAPIKey: {
+    id: 'Google Calendar API Key',
+    defaultMessage: 'Google Calendar API Key',
   },
   descriptionCalendarURL: {
-    id: 'Must point to an iCal/ics file.',
-    defaultMessage: 'Must point to an iCal/ics file.',
+    id: 'Must point to an iCal/ics file or a Google Calendar ID.',
+    defaultMessage: 'Must point to an iCal/ics file or a Google Calendar ID.',
+  },
+  descriptionGoogleCalendarAPIKey: {
+    id: 'See https://fullcalendar.io/docs/google-calendar for how to create a Google Calendar API Key.',
+    defaultMessage: 'See https://fullcalendar.io/docs/google-calendar for how to create a Google Calendar API Key.',
   },
   labelDayGridMonth: {
     id: 'Month',

--- a/src/components/manage/Blocks/FullCalendar/schema.js
+++ b/src/components/manage/Blocks/FullCalendar/schema.js
@@ -33,6 +33,7 @@ const FullCalendarBlockSchema = (intl) => {
         title: 'Default',
         fields: [
           'calendar_url',
+          'google_calendar_api_key',
           'initial_view',
           'toolbar_left',
           'toolbar_center',
@@ -49,6 +50,11 @@ const FullCalendarBlockSchema = (intl) => {
       calendar_url: {
         title: intl.formatMessage(messages.labelCalendarURL),
         description: intl.formatMessage(messages.descriptionCalendarURL),
+        type: 'string',
+      },
+      google_calendar_api_key: {
+        title: intl.formatMessage(messages.labelGoogleCalendarAPIKey),
+        description: intl.formatMessage(messages.descriptionGoogleCalendarAPIKey),
         type: 'string',
       },
       initial_view: {


### PR DESCRIPTION
This PR integrates @fullcalendar/google-calendar into volto-fullcalendar-block.

- Allows for a Google Calendar ID to be used in the calendar_url sidebar field.
- Adds a new google_calendar_api_key sidebar field for including the user's Google Calendar API Key

Thanks for your review and consideration.

Here is a screenshot of a Google Calendar in action:
<img width="925" alt="Screen Shot 2024-05-17 at 5 58 50 PM" src="https://github.com/mbarde/volto-fullcalendar-block/assets/1520484/2288cd67-059a-4908-a39c-be61a0486660">