### PR TITLE
Use React.Lazy to Improve site performace

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import React, { Suspense } from 'react';
+import { Loader } from 'semantic-ui-react';
 
 // Lazy load the components using different internal names
 const LazyFullCalendarBlockEdit = React.lazy(() => import('./manage/Blocks/FullCalendar/Edit'));
@@ -8,6 +9,7 @@ const LazyFullCalendarListing = React.lazy(() => import('./manage/Blocks/Listing
 // Create fallback component for Suspense
 const LoadingFallback = () => (
   <div>
+    <Loader active inline='centered' />
     <p>Loading...</p>
   </div>
 );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,32 @@
-import FullCalendarBlockEdit from './manage/Blocks/FullCalendar/Edit';
-import FullCalendarBlockView from './manage/Blocks/FullCalendar/View';
-import FullCalendarListing from './manage/Blocks/Listing/FullCalendar';
+import React, { Suspense } from 'react';
 
-export { FullCalendarBlockEdit, FullCalendarBlockView, FullCalendarListing };
+// Lazy load the components using different internal names
+const LazyFullCalendarBlockEdit = React.lazy(() => import('./manage/Blocks/FullCalendar/Edit'));
+const LazyFullCalendarBlockView = React.lazy(() => import('./manage/Blocks/FullCalendar/View'));
+const LazyFullCalendarListing = React.lazy(() => import('./manage/Blocks/Listing/FullCalendar'));
+
+// Create fallback component for Suspense
+const LoadingFallback = () => (
+  <div>
+    <p>Loading...</p>
+  </div>
+);
+
+// Export the components with the original names, wrapped in Suspense
+export const FullCalendarBlockEdit = (props) => (
+  <Suspense fallback={<LoadingFallback />}>
+    <LazyFullCalendarBlockEdit {...props} />
+  </Suspense>
+);
+
+export const FullCalendarBlockView = (props) => (
+  <Suspense fallback={<LoadingFallback />}>
+    <LazyFullCalendarBlockView {...props} />
+  </Suspense>
+);
+
+export const FullCalendarListing = (props) => (
+  <Suspense fallback={<LoadingFallback />}>
+    <LazyFullCalendarListing {...props} />
+  </Suspense>
+);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,34 +1,37 @@
-import React, { Suspense } from 'react';
+import React from 'react';
+import loadable from '@loadable/component';
 import { Loader } from 'semantic-ui-react';
 
-// Lazy load the components using different internal names
-const LazyFullCalendarBlockEdit = React.lazy(() => import('./manage/Blocks/FullCalendar/Edit'));
-const LazyFullCalendarBlockView = React.lazy(() => import('./manage/Blocks/FullCalendar/View'));
-const LazyFullCalendarListing = React.lazy(() => import('./manage/Blocks/Listing/FullCalendar'));
+// Lazy load the components using @loadable/component
+const FullCalendarBlockEdit = loadable(() =>
+  import('./manage/Blocks/FullCalendar/Edit'), {
+  fallback: (
+    <div>
+      <Loader active inline='centered' />
+      <p>Loading...</p>
+    </div>
+  ),
+});
 
-// Create fallback component for Suspense
-const LoadingFallback = () => (
-  <div>
-    <Loader active inline='centered' />
-    <p>Loading...</p>
-  </div>
-);
+const FullCalendarBlockView = loadable(() =>
+  import('./manage/Blocks/FullCalendar/View'), {
+  fallback: (
+    <div>
+      <Loader active inline='centered' />
+      <p>Loading...</p>
+    </div>
+  ),
+});
 
-// Export the components with the original names, wrapped in Suspense
-export const FullCalendarBlockEdit = (props) => (
-  <Suspense fallback={<LoadingFallback />}>
-    <LazyFullCalendarBlockEdit {...props} />
-  </Suspense>
-);
+const FullCalendarListing = loadable(() =>
+  import('./manage/Blocks/Listing/FullCalendar'), {
+  fallback: (
+    <div>
+      <Loader active inline='centered' />
+      <p>Loading...</p>
+    </div>
+  ),
+});
 
-export const FullCalendarBlockView = (props) => (
-  <Suspense fallback={<LoadingFallback />}>
-    <LazyFullCalendarBlockView {...props} />
-  </Suspense>
-);
-
-export const FullCalendarListing = (props) => (
-  <Suspense fallback={<LoadingFallback />}>
-    <LazyFullCalendarListing {...props} />
-  </Suspense>
-);
+// Export the components with the original names
+export { FullCalendarBlockEdit, FullCalendarBlockView, FullCalendarListing };

--- a/src/components/manage/Blocks/Listing/FullCalendar.jsx
+++ b/src/components/manage/Blocks/Listing/FullCalendar.jsx
@@ -1,19 +1,17 @@
-import React, { lazy, Suspense, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import listPlugin from '@fullcalendar/list';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import allLocales from '@fullcalendar/core/locales-all';
 import { flattenToAppURL } from '@plone/volto/helpers';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
 import config from '@plone/volto/registry';
 import { RRule, rrulestr } from 'rrule';
 import messages from '../FullCalendar/messages';
 
-// Lazy load FullCalendar and its plugins
-const FullCalendar = lazy(() => import('@fullcalendar/react'));
-const dayGridPlugin = lazy(() => import('@fullcalendar/daygrid'));
-const listPlugin = lazy(() => import('@fullcalendar/list'));
-const timeGridPlugin = lazy(() => import('@fullcalendar/timegrid'));
-const allLocales = lazy(() => import('@fullcalendar/core/locales-all'));
-
-/* returns all events, computed by the recurrence rule of an Event item */
+/* returns all events, computed by the reccurence rule of an Event item */
 const expand = (item) => {
   let recurrence = item.recurrence;
   if (item.recurrence.indexOf('DTSTART') < 0) {
@@ -46,9 +44,14 @@ const expand = (item) => {
 
 const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
   const intl = useIntl();
+
   const moment = momentlib.default;
   moment.locale(intl.locale);
 
+  /* server-side rendering with FullCalendar does not work here,
+     so we need to render after client-side hydration - as described here:
+     https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#option-2-lazily-show-component-with-uselayouteffect
+  */
   const [isClientSide, setIsClientSide] = useState(false);
 
   useEffect(() => {
@@ -62,6 +65,7 @@ const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
       if (!i.start) return false;
       if (i.recurrence) {
         recurrences = recurrences.concat(expand(i));
+        /* expand returns initial event as well, so we skip it here */
         return false;
       }
       return true;
@@ -87,9 +91,11 @@ const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
       end.getHours() === 23 &&
       end.getMinutes() === 59
     ) {
+      /* full day event */
       event.allDay = true;
     }
     if (
+      /* open end event */
       end.getHours() === 23 &&
       end.getMinutes() === 59
     ) {
@@ -126,13 +132,7 @@ const FullCalendarListing = ({ items, moment: momentlib, ...props }) => {
     ...(config.settings.fullcalendar?.additionalOptions || {}),
   };
 
-  return (
-    isClientSide && (
-      <Suspense fallback={<div>Loading...</div>}>
-        <FullCalendar events={events} {...fcOptions} />
-      </Suspense>
-    )
-  );
+  return isClientSide && <FullCalendar events={events} {...fcOptions} />;
 };
 
 export default injectLazyLibs(['moment'])(FullCalendarListing);


### PR DESCRIPTION
Pagespeed improvements by Lazy loading javascript chunk for the calendar so it is only loaded if the page is using the calendar variation.

Improvements in:

- Reduce JavaScript execution time - Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this.
- Minimize main-thread work - Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this.
- Reduce unused JavaScript - Reduce unused JavaScript and defer loading scripts until they are required to decrease bytes consumed by network activity. 